### PR TITLE
fix : rectification du nginx.conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,7 +6,7 @@ server {
     index index.php index.html index.htm;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
Bonjour,

J'ai rectifier le fichier nginx.conf, y avait un soucis pour les routes, il ne détectait pas le fichier index.

Ce qui causé des problèmes pour le routage.